### PR TITLE
Firefox 60 compatibility fixes (for Zotero 5.0.78)

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -22,7 +22,8 @@ function logMessage(msg) {
 
 function setDefaultPrefs() {
     let branch = Services.prefs.getDefaultBranch(PREF_BRANCH);
-    for (let [key, val] in Iterator(PREFS)) {
+    for (let key in PREFS) {
+        let val = PREFS[key];
         switch (typeof val) {
         case "boolean":
             branch.setBoolPref(key, val);

--- a/chrome/content/rtfScan.xul
+++ b/chrome/content/rtfScan.xul
@@ -9,7 +9,7 @@
 	title="&zotero.rtfScan.title;" width="700" height="580"
 	id="zotero-rtfScan">
 	
-	<script src="include.js"/>
+	<script src="chrome://zotero/content/include.js"/>
 	<script src="rtfScan.js"/>
 	
 	<wizardpage id="intro-page" label="&zotero.rtfScan.introPage.label;"
@@ -36,7 +36,7 @@
 			<description width="700" style="padding-top:1em">&zotero.rtfScan.introPage.description2;</description>
 		</vbox>
 		<vbox id="file-type-description-odf" class="file-type-description" hidden="true">
-			<description width="700">&zotero.odfScan.introPage.description.start;<label class="zotero-text-link" href="http://zotero-odf-scan.github.io/zotero-odf-scan/" value="&zotero.odfScan.introPage.link;"/>&zotero.odfScan.introPage.description.end;</description>
+			<description width="700">&zotero.odfScan.introPage.description.start;<label class="zotero-text-link" href="https://zotero-odf-scan.github.io/zotero-odf-scan/" value="&zotero.odfScan.introPage.link;" style="margin-left: 0; margin-right: 0;"/>&zotero.odfScan.introPage.description.end;</description>
 			<label style="color:black;margin:0 0 0.25em 2em;" value="{ *See* | Smith, A Title (2003) | | | zotero://select/items/0_AXVB9R }"/>
 			<label style="margin:0 0 0.75em 4em;font-style:italic;" value="&zotero.odfScan.introPage.example1;"/>
 			<label style="color:black;margin:0 0 0.25em 2em;" value="{ | Smith, A Title (2003) | p. 33 | (quoting Jones) | zotero://select/items/0_AXVB9R }"/>


### PR DESCRIPTION
Note that this won't work with versions of Zotero before 5.0.78, including their Juris-M equivalents, but I don't think it's worth the extra effort to maintain compatibility for a few more days.